### PR TITLE
box misbehavior headers and use internal error for decoding tm headers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,6 +94,9 @@ ibc-app-nft-transfer-types  = { version = "0.50.0", path = "./ibc-apps/ics721-nf
 
 ibc-proto = { version = "0.41.0", default-features = false }
 
+prost = { version = "0.12.3", default-features = false }
+bytes               = { version = "1.5.0", default-features = false }
+
 # cosmos dependencies
 tendermint                       = { version = "0.34.0", default-features = false }
 tendermint-light-client          = { version = "0.34.0", default-features = false }
@@ -105,3 +108,7 @@ tendermint-testgen               = { version = "0.34.0", default-features = fals
 # parity dependencies
 parity-scale-codec = { version = "3.6.5", default-features = false, features = ["full"] }
 scale-info         = { version = "2.10.0", default-features = false, features = ["derive"] }
+
+[patch.crates-io]
+aes-gcm-siv = { git = "https://github.com/RustCrypto/AEADs", rev = "6105d7a5591aefa646a95d12b5e8d3f55a9214ef" }
+curve25519-dalek = { git = "https://github.com/mina86/curve25519-dalek", rev = "8274d5cbb6fc3f38cdc742b4798173895cd2a290" }

--- a/ibc-clients/ics07-tendermint/types/Cargo.toml
+++ b/ibc-clients/ics07-tendermint/types/Cargo.toml
@@ -40,7 +40,7 @@ parity-scale-codec = { workspace = true, optional = true }
 scale-info         = { workspace = true, optional = true }
 
 # Solana and Composable specific
-solana-ed25519 = { git = "https://github.com/ComposableFi/emulated-light-client/", branch = "master", default-features = false }
+solana-signature-verifier = { git = "https://github.com/ComposableFi/emulated-light-client/", branch = "master", default-features = false }
 
 [dev-dependencies]
 serde_json     = { workspace = true }

--- a/ibc-clients/ics07-tendermint/types/Cargo.toml
+++ b/ibc-clients/ics07-tendermint/types/Cargo.toml
@@ -39,6 +39,9 @@ tendermint-proto                 = { workspace = true }
 parity-scale-codec = { workspace = true, optional = true }
 scale-info         = { workspace = true, optional = true }
 
+prost.workspace = true
+bytes.workspace = true
+
 # Solana and Composable specific
 solana-signature-verifier = { git = "https://github.com/ComposableFi/emulated-light-client/", branch = "master", default-features = false }
 

--- a/ibc-clients/ics07-tendermint/types/src/client_state/solana_verifier.rs
+++ b/ibc-clients/ics07-tendermint/types/src/client_state/solana_verifier.rs
@@ -28,15 +28,15 @@ impl tendermint::crypto::signature::Verifier for SigVerifier {
         } else {
             return Err(Error::UnsupportedKeyType);
         };
-        let pubkey = <&sigverify::PubKey>::try_from(pubkey.as_bytes())
+        let pubkey = <&solana_ed25519::PubKey>::try_from(pubkey.as_bytes())
             .map_err(|_| Error::MalformedPublicKey)?;
-        let sig = <&sigverify::Signature>::try_from(signature.as_bytes())
+        let sig = <&solana_ed25519::Signature>::try_from(signature.as_bytes())
             .map_err(|_| Error::MalformedSignature)?;
 
         // SAFETY: The function is always safe to run and if it returns non-null
         // than it returns a pointer to an object with static lifetime thus it’s
         // always sound to dereference it.
-        let verifier: Option<&sigverify::Verifier> = unsafe {
+        let verifier: Option<&solana_ed25519::Verifier> = unsafe {
             let ptr = get_global_ed25519_verifier() as *mut ();
             core::ptr::NonNull::new(ptr).map(|ptr| ptr.cast().as_ref())
         };

--- a/ibc-clients/ics07-tendermint/types/src/client_state/solana_verifier.rs
+++ b/ibc-clients/ics07-tendermint/types/src/client_state/solana_verifier.rs
@@ -28,20 +28,20 @@ impl tendermint::crypto::signature::Verifier for SigVerifier {
         } else {
             return Err(Error::UnsupportedKeyType);
         };
-        let pubkey = <&solana_ed25519::PubKey>::try_from(pubkey.as_bytes())
+        let pubkey = <&sigverify::ed25519::PubKey>::try_from(pubkey.as_bytes())
             .map_err(|_| Error::MalformedPublicKey)?;
-        let sig = <&solana_ed25519::Signature>::try_from(signature.as_bytes())
+        let sig = <&sigverify::ed25519::Signature>::try_from(signature.as_bytes())
             .map_err(|_| Error::MalformedSignature)?;
 
         // SAFETY: The function is always safe to run and if it returns non-null
         // than it returns a pointer to an object with static lifetime thus it’s
         // always sound to dereference it.
-        let verifier: Option<&solana_ed25519::Verifier> = unsafe {
+        let verifier: Option<&sigverify::Verifier> = unsafe {
             let ptr = get_global_ed25519_verifier() as *mut ();
             core::ptr::NonNull::new(ptr).map(|ptr| ptr.cast().as_ref())
         };
         match verifier {
-            Some(verifier) if verifier.exists(msg, pubkey, sig) => Ok(()),
+            Some(verifier) if verifier.verify(msg, pubkey, sig) => Ok(()),
             _ => Err(Error::VerificationFailed),
         }
     }

--- a/ibc-clients/ics07-tendermint/types/src/client_state/solana_verifier.rs
+++ b/ibc-clients/ics07-tendermint/types/src/client_state/solana_verifier.rs
@@ -41,7 +41,7 @@ impl tendermint::crypto::signature::Verifier for SigVerifier {
             core::ptr::NonNull::new(ptr).map(|ptr| ptr.cast().as_ref())
         };
         match verifier {
-            Some(verifier) if verifier.verify(msg, pubkey, sig) => Ok(()),
+            Some(verifier) if verifier.verify(msg, pubkey.as_ref(), sig.as_ref()).unwrap() => Ok(()),
             _ => Err(Error::VerificationFailed),
         }
     }

--- a/ibc-clients/ics07-tendermint/types/src/client_state/solana_verifier.rs
+++ b/ibc-clients/ics07-tendermint/types/src/client_state/solana_verifier.rs
@@ -28,15 +28,15 @@ impl tendermint::crypto::signature::Verifier for SigVerifier {
         } else {
             return Err(Error::UnsupportedKeyType);
         };
-        let pubkey = <&solana_ed25519::PubKey>::try_from(pubkey.as_bytes())
+        let pubkey = <&sigverify::PubKey>::try_from(pubkey.as_bytes())
             .map_err(|_| Error::MalformedPublicKey)?;
-        let sig = <&solana_ed25519::Signature>::try_from(signature.as_bytes())
+        let sig = <&sigverify::Signature>::try_from(signature.as_bytes())
             .map_err(|_| Error::MalformedSignature)?;
 
         // SAFETY: The function is always safe to run and if it returns non-null
         // than it returns a pointer to an object with static lifetime thus it’s
         // always sound to dereference it.
-        let verifier: Option<&solana_ed25519::Verifier> = unsafe {
+        let verifier: Option<&sigverify::Verifier> = unsafe {
             let ptr = get_global_ed25519_verifier() as *mut ();
             core::ptr::NonNull::new(ptr).map(|ptr| ptr.cast().as_ref())
         };

--- a/ibc-clients/ics07-tendermint/types/src/error.rs
+++ b/ibc-clients/ics07-tendermint/types/src/error.rs
@@ -51,6 +51,8 @@ pub enum Error {
     NegativeMaxClockDrift,
     /// missing latest height
     MissingLatestHeight,
+    /// decode error: `{0}`
+    Decode(prost::DecodeError),
     /// invalid raw header error: `{0}`
     InvalidRawHeader(TendermintError),
     /// invalid raw misbehaviour: `{reason}`

--- a/ibc-clients/ics07-tendermint/types/src/misbehaviour.rs
+++ b/ibc-clients/ics07-tendermint/types/src/misbehaviour.rs
@@ -17,16 +17,16 @@ const TENDERMINT_MISBEHAVIOUR_TYPE_URL: &str = "/ibc.lightclients.tendermint.v1.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Misbehaviour {
     client_id: ClientId,
-    header1: Header,
-    header2: Header,
+    header1: Box<Header>,
+    header2: Box<Header>,
 }
 
 impl Misbehaviour {
     pub fn new(client_id: ClientId, header1: Header, header2: Header) -> Self {
         Self {
             client_id,
-            header1,
-            header2,
+            header1: Box::new(header1),
+            header2: Box::new(header2),
         }
     }
 
@@ -98,8 +98,8 @@ impl From<Misbehaviour> for RawMisbehaviour {
         #[allow(deprecated)]
         RawMisbehaviour {
             client_id: value.client_id.to_string(),
-            header_1: Some(value.header1.into()),
-            header_2: Some(value.header2.into()),
+            header_1: Some((*value.header1).into()),
+            header_2: Some((*value.header2).into()),
         }
     }
 }


### PR DESCRIPTION
Using the existing fork to box the headers of misbehavior since they can get pretty large on the stack. Also for converting the TM headers from `Any`, using the `decode header` defined until ibc-rs 0.48.2 which uses internally defined error rather than calling `Protobuf` and formatting errors using string which seems to be taking a bit more stack than the latter causing it to overflow on the contract.