### PR TITLE
process tm verification only if client type is tendermint

### DIFF
--- a/ibc-core/ics25-handler/src/entrypoint.rs
+++ b/ibc-core/ics25-handler/src/entrypoint.rs
@@ -35,14 +35,17 @@ pub fn dispatch(
             },
             _ => panic!("Invalid message type"),
         };
-        let header =
-            ibc_client_tendermint_types::Header::try_from(header.clone().client_message).unwrap();
-        validate(ctx, router, msg.clone(), Some(header.clone()))?;
-        execute(ctx, router, msg, Some(header))?;
-    } else {
-        validate(ctx, router, msg.clone(), None)?;
-        execute(ctx, router, msg, None)?;
+        if header.client_id.as_str().contains("tendermint") {
+            let header =
+                ibc_client_tendermint_types::Header::try_from(header.clone().client_message)
+                    .unwrap();
+            validate(ctx, router, msg.clone(), Some(header.clone()))?;
+            execute(ctx, router, msg, Some(header))?;
+            return Ok(())
+        }
     }
+    validate(ctx, router, msg.clone(), None)?;
+    execute(ctx, router, msg, None)?;
 
     Ok(())
 }

--- a/ibc-core/ics25-handler/src/entrypoint.rs
+++ b/ibc-core/ics25-handler/src/entrypoint.rs
@@ -27,25 +27,16 @@ pub fn dispatch(
     router: &mut impl Router,
     msg: MsgEnvelope,
 ) -> Result<(), ContextError> {
-    if matches!(msg, MsgEnvelope::Client(ClientMsg::UpdateClient(_))) {
-        let header = match msg {
-            MsgEnvelope::Client(ref msg) => match msg {
-                ClientMsg::UpdateClient(msg) => msg,
-                _ => panic!("Invalid message type"),
-            },
-            _ => panic!("Invalid message type"),
-        };
-        if header.client_id.as_str().contains("tendermint") {
-            let header =
-                ibc_client_tendermint_types::Header::try_from(header.clone().client_message)
-                    .unwrap();
-            validate(ctx, router, msg.clone(), Some(header.clone()))?;
-            execute(ctx, router, msg, Some(header))?;
-            return Ok(())
+    let header = match msg {
+        MsgEnvelope::Client(ClientMsg::UpdateClient(ref msg))
+            if msg.client_id.as_str().contains("tendermint") =>
+        {
+            ibc_client_tendermint_types::Header::try_from(msg.client_message.clone()).ok()
         }
-    }
-    validate(ctx, router, msg.clone(), None)?;
-    execute(ctx, router, msg, None)?;
+        _ => None,
+    };
+    validate(ctx, router, msg.clone(), header.clone())?;
+    execute(ctx, router, msg, header)?;
 
     Ok(())
 }


### PR DESCRIPTION
Since we have clients other than tendermint, we should skip the special validate and execute methods if the client type is not tendermint since the conversion for tendermint was compute intensive and we wanted to reuse it.